### PR TITLE
Minor update to readme and src/unit_testing.R

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Make sure RStudio is closed before opening the unit testing script as this will 
 cd ./src/system_models/<modelobject>/
 rstudio unit_testing.R
 ```
+or in a Mac terminal
+```bash
+open -na Rstudio unit_testing.R
+```
 where `<modelobject>` is the name of the system model to be tested.
 The unit testing script can be run line by line to run a number of tests of the model objects. 
 An example from the leaf model object `unit_testing.R` script to run an ACi curve: 
@@ -60,6 +64,10 @@ The MAAT wrapper can also be tested to ensure the wrapper is working correctly a
 ```bash 
 cd ./src/
 rstudio unit_testing.R
+```
+or in a Mac terminal
+```bash
+open -na Rstudio unit_testing.R
 ```
 
 

--- a/src/unit_testing.R
+++ b/src/unit_testing.R
@@ -16,6 +16,7 @@
 # Wrapper
 # Leaf
 rm(list=ls())
+if (! file.exists('~/tmp')) dir.create('~/tmp',recursive=TRUE)
 
 source('wrapper_object.R')
 out <- wrapper_object$.test_simple()


### PR DESCRIPTION
Minor update to README to provide example of running Rstudio from command line in a Mac terminal

@walkeranthonyp Optional change or I can edit the change as well.  Just a heads up to Mac users