### PR TITLE
remove duplicate variable from millennialv2 model

### DIFF
--- a/src/system_models/soil_decomp/mimic_xmls/soil_decomp_millennialv2.xml
+++ b/src/system_models/soil_decomp/mimic_xmls/soil_decomp_millennialv2.xml
@@ -99,7 +99,6 @@
         <kld>1</kld>
         <sorp_p1>0.12</sorp_p1>
         <sorp_p2>0.216</sorp_p2>
-        <kld>1</kld>
         <cue_t>0.012</cue_t>
         <Taeref>15</Taeref>
         <pa>0.33</pa>

--- a/src/system_models/soil_decomp/soil_decomp_default.xml
+++ b/src/system_models/soil_decomp/soil_decomp_default.xml
@@ -221,7 +221,6 @@
         <kld>1</kld>
         <sorp_p1>0.12</sorp_p1>
         <sorp_p2>0.216</sorp_p2>
-        <kld>1</kld>
         <cue_t>0.012</cue_t>
         <Taeref>15</Taeref>
         <pa>0.33</pa>

--- a/src/system_models/soil_decomp/soil_decomp_object.R
+++ b/src/system_models/soil_decomp/soil_decomp_object.R
@@ -388,7 +388,6 @@ soil_decomp_object$pars <- list(
     kld = 1, #desorption coefficient
     sorp_p1 = .12, #sorption affinity parameter
     sorp_p2 = .216, #sorption affinity parameter
-    kld = 1, #desorption coefficient
     cue_t = 0.012, #slope of CUE temp sensitivity
     Taeref = 15,   #ref temp for CUE temp-dependence equation
     pa = 0.33,      #proportion agg breakdown into pom


### PR DESCRIPTION
Fixed one minor error (duplicate variable) that was causing error when running MillennialV2 from mod_mimic xml.